### PR TITLE
Added the xres_buf.v module to the verilog sources

### DIFF
--- a/verilog/frigate_timing_frontend.v
+++ b/verilog/frigate_timing_frontend.v
@@ -7,6 +7,7 @@
  * HSXO 4-16MHz
  * 16MHz R-C oscillator
  * 500kHz R-C oscillator
+ * Level shifter for xres4v2 RESETB signal
  *
  *-----------------------------------------------------
  */
@@ -52,7 +53,7 @@ module frigate_timing_frontend (
 
 /* Currently a black-box placeholder */
 
-    sky130_ef_ip__xtal_osc_32k LSXO(
+    sky130_ef_ip__xtal_osc_32k LSXO (
     `ifdef USE_POWER_PINS
         .avdd(vdda3),
         .avss(vssa3),
@@ -67,7 +68,7 @@ module frigate_timing_frontend (
         .dout(lsxo_dout)
     );
 
-    sky130_ef_ip__xtal_osc_16M HSXO(
+    sky130_ef_ip__xtal_osc_16M HSXO (
     `ifdef USE_POWER_PINS
         .avdd(vdda3),
         .avss(vssa3),
@@ -82,7 +83,7 @@ module frigate_timing_frontend (
         .dout(hsxo_dout)
     );
 
-    sky130_ef_ip__rc_osc_500k RC_OSC_500k(
+    sky130_ef_ip__rc_osc_500k RC_OSC_500k (
     `ifdef USE_POWER_PINS
         .avdd(vdda3),
         .avss(vssa3),
@@ -93,7 +94,7 @@ module frigate_timing_frontend (
         .dout(rc_osc_500k_dout)
     );
 
-    sky130_ef_ip__rc_osc_16M RC_OSC_16M(
+    sky130_ef_ip__rc_osc_16M RC_OSC_16M (
     `ifdef USE_POWER_PINS
         .avdd(vdda3),
         .avss(vssa3),
@@ -103,4 +104,17 @@ module frigate_timing_frontend (
         .ena(rc_osc_16M_ena),
         .dout(rc_osc_16M_dout)
     );
+
+    /* Note:  This module is defined in this directory */
+    xres_buf xres_level_shifter (
+    `ifdef USE_POWER_PINS
+        .VPWR(vdda3),	// FIXME:  This really should be vddio.
+        .VGND(vssd0),	// NOTE:  Cannot be isolated from digital ground
+        .LVPWR(vccd0),
+        .LVGND(vssd0),
+    `endif
+	.A(resetb_in_h),
+	.X(resetb_out_l)
+    );
+
 endmodule	// frigate_timing_frontend

--- a/verilog/xres_buf.v
+++ b/verilog/xres_buf.v
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2020 Efabless Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+
+// Module xres_buf is a level-shift buffer between the xres pad (used for
+// digital reset) and the caravel chip core.  The xres pad output is in
+// the 3.3V domain while the signal goes to the digital circuitry in the
+// 1.8V domain.
+
+//--------------------------------------------------------------------
+// xres_buf :  A high-to-low voltage domain level shifter for the
+// reset signal from the RESETB pin on the padframe.  The xres4v2
+// I/O cell does not have a low-voltage (1.8V) domain output.  To
+// trigger reset on the SoC digital block, running on vccd (1.8V),
+// the level shifter is needed.  Because the level shifter uses
+// the HVL library, it cannot be integrated directly into the rest
+// of the SoC, and so becomes its own subcell.  For the same reason,
+// it is easier to place that subcell in the analog timing frontend
+// module and routing input and output connections by hand.
+//--------------------------------------------------------------------
+
+module xres_buf (
+	X,
+	A,
+`ifdef USE_POWER_PINS
+	VPWR,
+	VGND,
+	LVPWR,
+	LVGND,
+`endif
+);
+
+    output X;
+    input  A;
+
+`ifdef USE_POWER_PINS
+    inout  VPWR;
+    inout  VGND;
+    inout  LVPWR;
+    inout  LVGND;
+`endif
+
+    sky130_fd_sc_hvl__lsbufhv2lv_1 lvlshiftdown (
+	`ifdef USE_POWER_PINS
+	.VPWR(VPWR),
+	.VPB(VPWR),
+	.LVPWR(LVPWR),
+	.VNB(VGND),
+	.VGND(VGND),
+`endif
+	.A(A),
+	.X(X)
+    );
+
+    sky130_fd_sc_hvl__decap_8 x3[4:0] (
+`ifdef USE_POWER_PINS
+	.VPWR(VPWR),
+	.VPB(VPWR),
+	.VNB(VGND),
+	.VGND(VGND)
+`endif
+    );
+
+    sky130_fd_sc_hvl__decap4 x4[1:0] (
+`ifdef USE_POWER_PINS
+	.VPWR(VPWR),
+	.VPB(VPWR),
+	.VNB(VGND),
+	.VGND(VGND)
+`endif
+    );
+
+    sky130_fd_sc_hvl__diode_2 x2 (
+`ifdef USE_POWER_PINS
+	.VPWR(VPWR),
+	.VPB(VPWR),
+	.VNB(VGND),
+	.VGND(VGND),
+`endif
+	.DIODE(A)
+    );
+endmodule


### PR DESCRIPTION
Added the xres_buf.v module to the verilog sources, and included the buffer in the timing frontend verilog, where it was missing (apparently having been previously simulated as a black box). NOTE:  In making this addition, I noticed that inside the timing frontend, the xres_buf cell power is connected to vdda3.  This will technically work, but as the RESETB line is derived from the VDDIO power supply, and the SoC should be able to work without VDDA3 applied, then the xres_buf should be connected to VDDIO, which would require adding VDDIO as an input to the timing frontend block.  This pull request resolves Issue #2.